### PR TITLE
🔨 fix: migrate to new catalog repo

### DIFF
--- a/src/components/molecules/ResponsiveSwitch.tsx
+++ b/src/components/molecules/ResponsiveSwitch.tsx
@@ -56,7 +56,7 @@ export default ({
           </Typography>
           <Typography variant="caption" className="sub-title">
             {subTitle}
-          </Typography>Ï
+          </Typography>
         </Grid>
         <Grid item xs={10} md={2} />
         <Grid item xs={2} md={2}>

--- a/src/libraries/catalogs/minio.ts
+++ b/src/libraries/catalogs/minio.ts
@@ -4,7 +4,7 @@ const CatalogSchemaMinio: CatalogScheme = {
   type: 'Storage',
   name: 'Minio',
   key: 'minio',
-  repo: 'https://github.com/kintohub/catalog-minio',
+  repo: 'https://github.com/kintoproj/catalog-minio',
   branch: 'master',
   tabs: [
     {

--- a/src/libraries/catalogs/mongodb.ts
+++ b/src/libraries/catalogs/mongodb.ts
@@ -4,7 +4,7 @@ const CatalogSchemaPostgreSQL: CatalogScheme = {
   type: 'Database',
   name: 'MongoDB',
   key: 'mongodb',
-  repo: 'https://github.com/kintohub/catalog-mongodb',
+  repo: 'https://github.com/kintoproj/catalog-mongodb',
   branch: 'master',
   tabs: [
     {

--- a/src/libraries/catalogs/mysql.ts
+++ b/src/libraries/catalogs/mysql.ts
@@ -4,7 +4,7 @@ const CatalogSchemaPostgreSQL: CatalogScheme = {
   type: 'Database',
   name: 'MySQL',
   key: 'mysql',
-  repo: 'https://github.com/kintohub/catalog-mysql',
+  repo: 'https://github.com/kintoproj/catalog-mysql',
   branch: 'master',
   tabs: [
     {

--- a/src/libraries/catalogs/postgres.ts
+++ b/src/libraries/catalogs/postgres.ts
@@ -4,7 +4,7 @@ const CatalogSchemaPostgreSQL: CatalogScheme = {
   type: 'Database',
   name: 'PostgreSQL',
   key: 'postgresql',
-  repo: 'https://github.com/kintohub/catalog-postgresql',
+  repo: 'https://github.com/kintoproj/catalog-postgresql',
   branch: 'master',
   tabs: [
     {

--- a/src/libraries/catalogs/redis.ts
+++ b/src/libraries/catalogs/redis.ts
@@ -4,7 +4,7 @@ const CatalogSchemaRedisSQL: CatalogScheme = {
   type: 'Database',
   name: 'Redis',
   key: 'redis',
-  repo: 'https://github.com/kintohub/catalog-redis',
+  repo: 'https://github.com/kintoproj/catalog-redis',
   branch: 'master',
   tabs: [
     {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] The code passes all tests and able to build

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ..., provide screenshots if necessary)
We were using `ssd` storage class for all catalogs by default before, which is not a standard storage class available on every cloud provider.  In this PR we migrate to opensource catalog repo (from `kintohub/catalog-*` to `kintoproj/catalog-*`), which already fixed the storage-class issues.

Fix https://github.com/kintoproj/kintohub/issues/3