### PR TITLE
🌟feat: internal API proxy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,5 @@ build
 
 # prevent shipping local development html
 public/index-*.html
+
+.env*

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,16 +11,12 @@ RUN yarn install --prod
 COPY . .
 RUN NODE_ENV=production yarn build
 
-FROM node:12-alpine
-RUN apk update && apk add --no-cache bash git
-RUN yarn global add serve
-WORKDIR /usr/src/app
+FROM nginx:1.18
+
+WORKDIR /usr/share/nginx/html
 COPY --from=0 /usr/src/app/build .
 COPY --from=0 /usr/src/app/scripts/replaceEnvVars.sh .
-EXPOSE 5000
 
-# avoid building everytime
-ARG GITHUB_SHA_ARG
-ENV GITHUB_SHA=$GITHUB_SHA_ARG
+COPY --from=0 /usr/src/app/nginx/nginx.conf /etc/nginx/conf.d/default.conf
 
-CMD ./replaceEnvVars.sh && serve -s .
+CMD ./replaceEnvVars.sh && nginx -g 'daemon off;'

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -4,8 +4,15 @@ server {
 
     root         /usr/share/nginx/html;
     index        index.html;
+
     location /api {
-        proxy_pass http://localhost:8090;
+        rewrite /api/(.*) /$1  break;
+        proxy_pass http://kinto-core:8090;
+        proxy_set_header   Host $host;
+    }
+
+    location /app {
+        try_files $uri $uri/ /index.html =404;
     }
 
 }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,11 @@
+server {
+
+    listen 80;
+
+    root         /usr/share/nginx/html;
+    index        index.html;
+    location /api {
+        proxy_pass http://localhost:8090;
+    }
+
+}


### PR DESCRIPTION
solving [this](https://github.com/kintoproj/kinto-dashboard/issues/19)

We had the deployed dashboard connecting to the kinto-core API through the public network. (e.g. https://core.kinto.somedomain.com)
But for the case if we want to do port-forwarding, we have to forward both dashboard and the core

Here the idea is to do a reverse proxy inside the dashboard container, which forwards the connection to core through internal k8s connection (i.e. pod to pod connection via http://kinto-core:8090), and expose the proxy via `/api/*` 

So if we do port-forwarding, we can expose only the dashboard and without any modifications to any env vars as we always connect to `/api` 